### PR TITLE
fix: persistent score display and controls

### DIFF
--- a/snake.js
+++ b/snake.js
@@ -40,6 +40,10 @@ function initSnakeGame(canvas, infoContainer) {
   overlay.style.display = 'none';
   overlay.style.zIndex = '10';
   infoContainer.parentElement.appendChild(overlay);
+  // Dedicated score display
+  const scoreDisplay = document.createElement('div');
+  scoreDisplay.textContent = `${currentLang === 'en' ? 'Score' : 'Score'}: ${score}`;
+  infoContainer.appendChild(scoreDisplay);
   // Controls container
   const controls = document.createElement('div');
   controls.style.marginTop = '0.5rem';
@@ -100,10 +104,8 @@ function initSnakeGame(canvas, infoContainer) {
     ctx.beginPath();
     ctx.rect(cheese.x * cellSize + 4, cheese.y * cellSize + 4, cellSize - 8, cellSize - 8);
     ctx.fill();
-    // Score display
-    infoContainer.textContent = `${currentLang === 'en' ? 'Score' : 'Score'}: ${score}`;
-    // Add controls again (because text replacement removed them)
-    infoContainer.appendChild(controls);
+    // Update score display without clearing the container
+    scoreDisplay.textContent = `${currentLang === 'en' ? 'Score' : 'Score'}: ${score}`;
   }
 
   function update() {


### PR DESCRIPTION
## Summary
- keep snake game controls persistent by adding a dedicated score display element inside the info container
- update only the score element each frame instead of clearing and rebuilding controls

## Testing
- `node <<'NODE'
class Element {
  constructor(tag) {
    this.tagName = tag;
    this.children = [];
    this.textContent = '';
    this.style = {};
    this.parentElement = null;
    this.listeners = {};
  }
  appendChild(child) { child.parentElement = this; this.children.push(child); return child; }
  addEventListener(event, handler) { this.listeners[event] = handler; }
}
const document = { createElement: tag => new Element(tag), documentElement: {} };
const window = { addEventListener: () => {}, speechSynthesis: { getVoices: () => [], cancel: () => {}, speak: () => {} } };
function getComputedStyle() { return { getPropertyValue: () => '#fff' }; }
global.document = document; global.window = window; global.getComputedStyle = getComputedStyle;
currentLang = 'en';
getDailyList = () => [{ fr: 'fromage', en: 'cheese', ipa: 'fʁɔ.maʒ' }];
speak = () => {};
const canvas = new Element('canvas');
canvas.width=400;canvas.height=400;
canvas.getContext = () => ({fillStyle:'',fillRect:()=>{},beginPath:()=>{},arc:()=>{},fill:()=>{},rect:()=>{}});
canvas.addEventListener=()=>{};
const info = new Element('div');
const parent = new Element('div');
parent.appendChild(info);
const fs=require('fs');const vm=require('vm');
vm.runInThisContext(fs.readFileSync('snake.js','utf8'));
initSnakeGame(canvas,info);
const originalControls=info.children[1];
setTimeout(()=>{
  console.log('controls count', info.children[1].children.length);
  console.log('controls unchanged', info.children[1]===originalControls);
  console.log('score text', info.children[0].textContent);
},700);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68960dd7b6e88320b8a54ff6f0fad140